### PR TITLE
fix bug with animations & styling in safari/mobile safari

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -54,6 +54,9 @@
       }
 
       @keyframes spin {
+        0% {
+          transform: rotate(0deg);
+        }
         100% {
           transform: rotate(359deg);
         }
@@ -72,7 +75,7 @@
         60% {
           transform: rotate(-3deg);
         }
-        90%: {
+        90% {
           transform: rotate(0deg);
         }
       }

--- a/templates/svg/drop-shadow-filter
+++ b/templates/svg/drop-shadow-filter
@@ -1,0 +1,10 @@
+<filter id="drop-shadow">
+  <feGaussianBlur in="SourceAlpha" stdDeviation="0"/>
+  <feOffset dx="0" dy="0" result="offsetblur"/>
+  <feFlood flood-color="#ffffff"/>
+  <feComposite in2="offsetblur" operator="in"/>
+  <feMerge>
+    <feMergeNode/>
+    <feMergeNode in="SourceGraphic"/>
+  </feMerge>
+</filter>

--- a/templates/svg/dryer.svg
+++ b/templates/svg/dryer.svg
@@ -10,6 +10,7 @@
   xml:space="preserve"
   class="machine dryer"
 >
+  <defs>{% include './svg/drop-shadow-filter' %}</defs>
   <g>
     <path
       d="M352.7,0H8.5C4,0,0.4,3.6,0.4,8.1v344.2c0,4.5,3.6,8.1,8.1,8.1h344.2c4.5,0,8.1-3.6,8.1-8.1V8.1C360.8,3.6,357.2,0,352.7,0
@@ -24,6 +25,5 @@
 		"
     />
   </g>
-  <text class="label label-offset" x="50%" y="55%">Offline</text>
-  <text class="label" x="50%" y="55%">Offline</text>
+  <text class="label" x="50%" y="55%" filter="url(#drop-shadow)">Offline</text>
 </svg>

--- a/templates/svg/washer.svg
+++ b/templates/svg/washer.svg
@@ -7,6 +7,7 @@
   enable-background="new 0 0 342.863 342.863"
   class="machine washer"
 >
+  <defs>{% include './svg/drop-shadow-filter' %}</defs>
   <g>
     <path
       d="M335.363,0H7.5C3.357,0,0,3.358,0,7.5v327.863c0,4.142,3.357,7.5,7.5,7.5h327.863c4.143,0,7.5-3.358,7.5-7.5V7.5   C342.863,3.358,339.506,0,335.363,0z M327.863,15v50.825H15V15H327.863z M15,327.863V80.825h312.863v247.039H15z"
@@ -22,6 +23,5 @@
       d="m208.19,46.802h25.371c4.143,0 7.5-3.358 7.5-7.5s-3.357-7.5-7.5-7.5h-25.371c-4.143,0-7.5,3.358-7.5,7.5s3.358,7.5 7.5,7.5z"
     />
   </g>
-  <text class="label label-offset" x="50%" y="55%">Offline</text>
-  <text class="label" x="50%" y="55%">Offline</text>
+  <text class="label" x="50%" y="55%" filter="url(#drop-shadow)">Offline</text>
 </svg>


### PR DESCRIPTION
Small CSS bug led to the animations not working on safari or mobile safari, this should fix that. In Safari, you have to specify a 0% to tell the browser how the animation should start, otherwise it just doesn't work apparently.